### PR TITLE
Capture window closing; copy Enemies.txt during build

### DIFF
--- a/TerminalRPG.vcxproj
+++ b/TerminalRPG.vcxproj
@@ -93,6 +93,9 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Console</SubSystem>
     </Link>
+    <PostBuildEvent>
+      <Command>xcopy "$(SolutionDir)Enemies.txt" "$(OutDir)"</Command>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
@@ -117,6 +120,9 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
     </Link>
+    <PostBuildEvent>
+      <Command>xcopy "$(SolutionDir)Enemies.txt" "$(OutDir)"</Command>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="enemy.cpp" />

--- a/main.cpp
+++ b/main.cpp
@@ -7,38 +7,43 @@
 using namespace std;
 using namespace std::chrono;
 
+void run() {
+  high_resolution_clock::time_point previous = high_resolution_clock::now();
+  Inventory temp;
+  Game game;
+  if (!game.getAllEnemies())
+  {
+    cout << "Someone can't program a game right. Or maybe it's just user error." << endl;
+    return;
+  }
+  Player user;
+  game.displayIntro();
+
+  // Ends the game if the player chose to.
+  if (game.selectScreen() == 4)
+  {
+    return;
+  }
+
+  user.setName(game.promptAndGetName());
+  user.setInventory(temp);
+  game.setPlayer(user);
+  game.sleepFor();
+  game.displayLore();
+
+  high_resolution_clock::time_point lap = high_resolution_clock::now();
+  duration<double, micro> seed_clock = lap - previous;
+  game.setSeed(seed_clock.count());
+
+  do
+  {
+  } while(game.menu());
+}
+
 int main()
 {
-    high_resolution_clock::time_point previous = high_resolution_clock::now();
-    Inventory temp;
-    Game game;
-    if(!game.getAllEnemies())
-    {
-        cout << "Someone can't program a game right. Or maybe it's just user error." << endl;
-        return 0;
-    }
-    Player user;
-    game.displayIntro();
-
-    // Ends the game if the player chose to.
-    if(game.selectScreen() == 4)
-    {
-        return 0;
-    }
-
-    user.setName(game.promptAndGetName());
-    user.setInventory(temp);
-    game.setPlayer(user);
-    game.sleepFor();
-    game.displayLore();
-
-    high_resolution_clock::time_point lap = high_resolution_clock::now();
-    duration<double, micro> seed_clock = lap - previous;
-    game.setSeed(seed_clock.count());
-
-    do
-    {
-    } while(game.menu());
-
-    return 0;
+  run();
+  cout << "Press Enter to close!" << endl;
+  string dummy;
+  getline(cin, dummy);
 }


### PR DESCRIPTION
## Bug fixes
- When running the program from the File Explorer (i.e. double-clicking it), the window would automatically close when the program finished. Now, the user is prompted to press Enter before the window closes.
- If Enemies.txt is not present, then the program will fail upon startup. This copies the text file to the build directory to help simplify distribution.