### PR TITLE
fix: During build, force overwrite Enemies.txt

### DIFF
--- a/TerminalRPG.vcxproj
+++ b/TerminalRPG.vcxproj
@@ -94,7 +94,7 @@
       <SubSystem>Console</SubSystem>
     </Link>
     <PostBuildEvent>
-      <Command>xcopy "$(SolutionDir)Enemies.txt" "$(OutDir)"</Command>
+      <Command>xcopy /y "$(SolutionDir)Enemies.txt" "$(OutDir)"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -121,7 +121,7 @@
       <OptimizeReferences>true</OptimizeReferences>
     </Link>
     <PostBuildEvent>
-      <Command>xcopy "$(SolutionDir)Enemies.txt" "$(OutDir)"</Command>
+      <Command>xcopy /y "$(SolutionDir)Enemies.txt" "$(OutDir)"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>


### PR DESCRIPTION
## Bug fixes
- During build, `Enemies.txt` now copies to the build directory even if it already exists.